### PR TITLE
Notebook for weekly penalties analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 # Dataset files
 dataset/*.csv.bz2
+
+# Spark
+**/spark_warehouse
+**/*.parquet
+
+# Jupyter
+**/.ipynb_checkpoints

--- a/notebooks/penalty.ipynb
+++ b/notebooks/penalty.ipynb
@@ -1,0 +1,268 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Big Data Project\n",
+    "\n",
+    "The goal of the project is to infer qualitative data regarding USA flights during the years 1994-2008. The data can be downloaded from [stat-computing.org](http://stat-computing.org/dataexpo/2009/the-data.html).\n",
+    "\n",
+    "In this notebook we are computing a weekly \"**penalty**\" score for each airport that depends on both the its incoming and outgoing\n",
+    "flights. The score adds `0.5` for each incoming flight that is more than _15 minutes_ late, and `1` for\n",
+    "each outgoing flight that is more than _15 minutes_ late."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialize PySpark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find Apache Spark on this machine\n",
+    "import findspark\n",
+    "findspark.init()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "# Build a Spark SQL Session for DataFrames\n",
+    "master = 'local[2]'\n",
+    "appName = 'Airport Weekly Penalty'\n",
+    "spark = SparkSession \\\n",
+    "    .builder \\\n",
+    "    .appName(appName) \\\n",
+    "    .master(master) \\\n",
+    "    .getOrCreate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "full_data = '../dataset/*.csv.bz2'\n",
+    "penalty_data = '../dataset/penalty_dataset.parquet'\n",
+    "\n",
+    "path = Path(penalty_data)\n",
+    "# If reduced dataset is not found, load the full compressed dataset and reduce it.\n",
+    "# This is going to take lot of time. Just wait.\n",
+    "if not path.is_dir():\n",
+    "    df = spark.read.csv(full_data, inferSchema=True, header=True, sep=',')\n",
+    "    df.select(df['Year'], df['Month'], df['DayofMonth'], \\\n",
+    "          df['DayOfWeek'], df['DepTime'], df['CRSDepTime'], \\\n",
+    "          df['ArrTime'], df['CRSArrTime'], df['ArrDelay'], \\\n",
+    "          df['DepDelay'], df['Origin'], df['Dest'], df['Cancelled']) \\\n",
+    "    .replace('NA', None) \\\n",
+    "    .write \\\n",
+    "    .save(penalty_data, format='parquet')\n",
+    "\n",
+    "# Load the reduced dataset\n",
+    "df = spark.read.load(penalty_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root\n",
+      " |-- Year: integer (nullable = true)\n",
+      " |-- Month: integer (nullable = true)\n",
+      " |-- DayofMonth: integer (nullable = true)\n",
+      " |-- DayOfWeek: integer (nullable = true)\n",
+      " |-- DepTime: string (nullable = true)\n",
+      " |-- CRSDepTime: integer (nullable = true)\n",
+      " |-- ArrTime: string (nullable = true)\n",
+      " |-- CRSArrTime: integer (nullable = true)\n",
+      " |-- ArrDelay: string (nullable = true)\n",
+      " |-- DepDelay: string (nullable = true)\n",
+      " |-- Origin: string (nullable = true)\n",
+      " |-- Dest: string (nullable = true)\n",
+      " |-- Cancelled: integer (nullable = true)\n",
+      "\n",
+      "+----+-----+----------+---------+-------+----------+-------+----------+--------+--------+------+----+---------+\n",
+      "|Year|Month|DayofMonth|DayOfWeek|DepTime|CRSDepTime|ArrTime|CRSArrTime|ArrDelay|DepDelay|Origin|Dest|Cancelled|\n",
+      "+----+-----+----------+---------+-------+----------+-------+----------+--------+--------+------+----+---------+\n",
+      "|1995|    1|         6|        5|    657|       645|    952|       937|      15|      12|   ORD| PHL|        0|\n",
+      "|1995|    1|         7|        6|    648|       645|    938|       937|       1|       3|   ORD| PHL|        0|\n",
+      "|1995|    1|         8|        7|    649|       645|    932|       937|      -5|       4|   ORD| PHL|        0|\n",
+      "|1995|    1|         9|        1|    645|       645|    928|       937|      -9|       0|   ORD| PHL|        0|\n",
+      "|1995|    1|        10|        2|    645|       645|    931|       937|      -6|       0|   ORD| PHL|        0|\n",
+      "|1995|    1|        11|        3|    646|       645|    929|       937|      -8|       1|   ORD| PHL|        0|\n",
+      "|1995|    1|        12|        4|   null|       645|   null|       937|    null|    null|   ORD| PHL|        1|\n",
+      "|1995|    1|        13|        5|    644|       645|    953|       937|      16|      -1|   ORD| PHL|        0|\n",
+      "|1995|    1|        14|        6|    644|       645|    938|       937|       1|      -1|   ORD| PHL|        0|\n",
+      "|1995|    1|        15|        7|    643|       645|    940|       937|       3|      -2|   ORD| PHL|        0|\n",
+      "+----+-----+----------+---------+-------+----------+-------+----------+--------+--------+------+----+---------+\n",
+      "only showing top 10 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Explore the data\n",
+    "df.printSchema()\n",
+    "df.show(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Drop entries with 'na' departure and arrival time\n",
+    "df = df.dropna(subset=['DepTime', 'ArrTime'])\n",
+    "\n",
+    "# Parse dates to datetime format\n",
+    "import datetime\n",
+    "import pyspark.sql.functions as F\n",
+    "from pyspark.sql.types import TimestampType, IntegerType\n",
+    "\n",
+    "make_date = lambda year, month, day : datetime.datetime(year, month, day) \n",
+    "make_date = F.udf(make_date, TimestampType())\n",
+    "\n",
+    "week_year = lambda date : date.isocalendar()[1]\n",
+    "week_year = F.udf(week_year, IntegerType())\n",
+    "\n",
+    "df = df.select(make_date(df['Year'], df['Month'], df['DayofMonth']).alias('Date'), \\\n",
+    "               'DayOfWeek', 'DepTime', 'ArrTime', 'ArrDelay', 'DepDelay', 'Origin', 'Dest')\n",
+    "df = df.select('Date', week_year('Date').alias('WeekYear'), 'ArrDelay', 'DepDelay', 'Origin', 'Dest')\n",
+    "# df.show(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Flights that are more than 15 minutes late\n",
+    "left_late = df.filter(df['DepDelay'] > 15)\n",
+    "arrived_late = df.filter(df['ArrDelay'] > 15)\n",
+    "\n",
+    "# Number of times per week an airport had a departure or an arrival more than 15 minutes late\n",
+    "incoming_late = arrived_late.groupBy([F.year('Date').alias('Year'), 'WeekYear', arrived_late['Dest'].alias('Airport')]).count()\n",
+    "outgoing_late = left_late.groupBy([F.year('Date').alias('Year'), 'WeekYear', left_late['Origin'].alias('Airport')]).count()\n",
+    "\n",
+    "# incoming_late.show(10)\n",
+    "# outgoing_late.show(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Penalties on arrivals and departures\n",
+    "incoming_factor = 0.5\n",
+    "outgoing_factor = 1.0\n",
+    "\n",
+    "incoming_penalty = incoming_late.select('Year', 'WeekYear', 'Airport', (incoming_late['count'] * incoming_factor).alias('Penalty'))\n",
+    "outgoing_penalty = outgoing_late.select('Year', 'WeekYear', 'Airport', (outgoing_late['count'] * outgoing_factor).alias('Penalty'))\n",
+    "\n",
+    "# incoming_penalty.show(10)\n",
+    "# outgoing_penalty.show(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sum up the penalties\n",
+    "penalties = incoming_penalty.unionAll(outgoing_penalty) \\\n",
+    "                .groupBy('Year', 'WeekYear', 'Airport').sum('Penalty') \\\n",
+    "                .withColumnRenamed('sum(Penalty)', 'WeeklyPenalty')\n",
+    "\n",
+    "# penalties.show(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Store output Dataframe (or load it if already existing)\n",
+    "final_dataset = '../dataset/penalty_analitics.parquet'\n",
+    "\n",
+    "path= Path(final_dataset)\n",
+    "if not path.is_dir():\n",
+    "    penalties.write.mode('overwrite').save(final_dataset, format='parquet')\n",
+    "else:\n",
+    "    penalties = spark.read.load(final_dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(1995, 4, 'OAK', 356.5), (1995, 1, 'OMA', 110.0), (1995, 4, 'OTZ', 4.0), (1995, 3, 'FCA', 2.0), (1995, 4, 'CDV', 2.0), (1995, 6, 'FCA', 2.5), (1995, 7, 'KSM', 0.5), (1995, 9, 'ABQ', 198.5), (1995, 9, 'BOS', 775.5), (1995, 9, 'BZN', 11.5), (1995, 6, 'CHS', 38.0), (1995, 11, 'SAT', 100.0), (1995, 13, 'MYR', 2.0), (1995, 13, 'ORD', 1249.0), (1995, 11, 'LAN', 9.0), (1995, 17, 'TPA', 165.5), (1995, 14, 'MBS', 16.0), (1995, 16, 'AUS', 222.5), (1995, 20, 'PNS', 25.0), (1995, 18, 'RDU', 64.5), (1995, 18, 'LBB', 31.5), (1995, 21, 'MFR', 8.5), (1995, 22, 'AGS', 12.0), (1995, 22, 'BOS', 240.5), (1995, 22, 'BRW', 8.0), (1995, 22, 'CAK', 2.5), (1995, 18, 'DAY', 32.0), (1995, 23, 'MFR', 8.0), (1995, 31, 'SLC', 482.0), (1995, 28, 'OME', 8.0), (1995, 29, 'ORF', 79.5), (1995, 28, 'DTW', 1047.0), (1995, 31, 'LAN', 20.5), (1995, 33, 'ORD', 2648.0), (1995, 32, 'ERI', 6.5), (1995, 34, 'JAC', 5.5), (1995, 35, 'LAN', 2.5), (1995, 35, 'BDL', 67.0), (1995, 37, 'TVC', 1.0), (1995, 39, 'GSO', 51.0), (1995, 37, 'HNL', 58.5), (1995, 37, 'JNU', 22.0), (1995, 37, 'ALB', 31.0), (1995, 44, 'CLT', 727.5), (1995, 41, 'FAT', 8.0), (1995, 46, 'PNS', 19.0), (1995, 46, 'TVC', 7.5), (1995, 45, 'MCO', 271.0), (1995, 48, 'MKE', 67.5), (1995, 47, 'HSV', 13.0), (1995, 50, 'SEA', 700.5), (1995, 51, 'BOS', 1246.0), (1994, 2, 'LEX', 24.0), (1994, 2, 'TOL', 10.5), (1994, 4, 'BNA', 291.0), (1994, 2, 'HPN', 28.0), (1994, 2, 'MAF', 8.0), (1994, 2, 'GEG', 33.0), (1994, 5, 'DSM', 17.0), (1994, 4, 'VPS', 2.5), (1994, 3, 'MLI', 14.5), (1994, 1, 'STT', 18.0), (1994, 6, 'TPA', 633.0), (1994, 7, 'LEX', 9.0), (1994, 6, 'BIS', 10.0), (1994, 5, 'DLH', 3.0), (1994, 9, 'MLI', 12.0), (1994, 5, 'SIT', 4.5), (1994, 12, 'CLE', 240.5), (1994, 17, 'CLT', 524.0), (1994, 15, 'OAJ', 3.0), (1994, 14, 'ABE', 10.0), (1994, 15, 'CAK', 1.5), (1994, 16, 'ONT', 34.0), (1994, 18, 'SYR', 18.0), (1994, 19, 'LBB', 31.5), (1994, 21, 'OMA', 35.0), (1994, 19, 'ICT', 16.5), (1994, 20, 'FWA', 4.0), (1994, 20, 'DLG', 2.0), (1994, 24, 'MOT', 1.5), (1994, 24, 'SBA', 6.5), (1994, 30, 'OKC', 50.0), (1994, 28, 'PDX', 131.0), (1994, 33, 'SRQ', 34.5), (1994, 33, 'HNL', 35.0), (1994, 35, 'FAT', 10.0), (1994, 36, 'PHX', 228.5), (1994, 36, 'ROA', 3.0), (1994, 36, 'ABQ', 44.5), (1994, 39, 'LIT', 18.5), (1994, 36, 'ONT', 26.0), (1994, 39, 'GEG', 17.5), (1994, 39, 'IAD', 71.0), (1994, 36, 'BFL', 1.0), (1994, 42, 'BWI', 188.0), (1994, 43, 'MYR', 1.0), (1994, 40, 'JAN', 19.0), (1994, 42, 'MFE', 37.5), (1994, 43, 'BET', 3.0)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Output a list of tuples of schema:\n",
+    "# ('Year', 'WeekYear', 'Airport', 'WeeklyPenalty')\n",
+    "penalty_data = penalties.rdd.map(tuple).collect()\n",
+    "print(penalty_data[:100])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This is the first version of the Jupyter Notebook to extract **airport weekly penalties** from our data.

For now, no data visualization is provided, just information retrieval.

A sample of the final output is the following:
```py
# Schema: ('Year', 'WeekYear', 'Airport', 'WeeklyPenalty')
[(1995, 4, 'OAK', 356.5),
 (1995, 1, 'OMA', 110.0),
 (1995, 4, 'OTZ', 4.0),
 (1995, 3, 'FCA', 2.0),
 (1995, 4, 'CDV', 2.0),
 (1995, 6, 'FCA', 2.5),
 (1995, 7, 'KSM', 0.5),
 (1995, 9, 'ABQ', 198.5),
 (1995, 9, 'BOS', 775.5),
 ...
]
```