### PR TITLE
Significant performance improvement in penalty notebook

### DIFF
--- a/notebooks/penalty.ipynb
+++ b/notebooks/penalty.ipynb
@@ -285,24 +285,38 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Weekly penalties over a year analytics "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
     "def get_pd_dataframe(airport, years, df):\n",
-    "    df = df.filter(F.col('Airport') == airport) \\\n",
-    "           .drop('Airport')\n",
+    "    rows = df.filter(F.col('Airport') == airport) \\\n",
+    "             .filter(F.col('Year').isin(*years)) \\\n",
+    "             .select('Year', 'WeekYear', 'WeeklyPenalty') \\\n",
+    "             .orderBy('Year', 'WeekYear') \\\n",
+    "             .collect()\n",
     "    \n",
-    "    res = df.select('WeekYear').distinct()\n",
-    "    for year in years:\n",
-    "        yearly = df.filter(df['Year'] == year) \\\n",
-    "                   .select('WeekYear', 'WeeklyPenalty') \\\n",
-    "                   .withColumnRenamed('WeeklyPenalty', str(year))\n",
-    "        res = res.join(yearly, 'WeekYear', 'outer')\n",
-    "    \n",
-    "    res = res.orderBy('WeekYear').toPandas()\n",
-    "    res.set_index('WeekYear', inplace=True)\n",
+    "    nb_years = len(years)\n",
+    "    nb_weeks = 52\n",
+    "    data = np.zeros((nb_weeks, nb_years))\n",
+    "    for row in rows:\n",
+    "        year = row[0] - years[0]\n",
+    "        week = row[1] - 1\n",
+    "        pen = row[2]\n",
+    "\n",
+    "        if week > 51: continue\n",
+    "        data[week, year] = pen\n",
+    "    columns = [str(y) for y in years]\n",
+    "    indices = range(1, 53)\n",
+    "    res = pd.DataFrame(data=data, columns=columns, index=indices)\n",
     "    return res\n",
     "\n",
     "def plot_penalty_time_series(airport, years, df):\n",
@@ -315,19 +329,98 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Average penalty in a year"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_average_df(airport, years, df):\n",
+    "    rows = df.filter(F.col('Airport') == airport) \\\n",
+    "             .filter(F.col('Year').isin(*years)) \\\n",
+    "             .groupBy('Year') \\\n",
+    "             .avg('WeeklyPenalty') \\\n",
+    "             .withColumnRenamed('avg(WeeklyPenalty)', 'AveragePenalty') \\\n",
+    "             .select('Year', 'AveragePenalty') \\\n",
+    "             .collect()\n",
+    "    \n",
+    "    nb_years = len(years)\n",
+    "    data = np.zeros(nb_years)\n",
+    "    for row in rows:\n",
+    "        year = row[0] - years[0]\n",
+    "        avg_pen = row[1]\n",
+    "        data[year] = avg_pen \n",
+    "    res = pd.DataFrame({airport: data}, index=years)\n",
+    "    return res\n",
+    "\n",
+    "def plot_average_penalty(airport, years, df):\n",
+    "    df = get_average_df(airport, years, df)\n",
+    "    title = '{} Airport - Average Penalties'.format(airport)\n",
+    "    if df.empty:\n",
+    "        print('No data for airport {}'.format(airport))\n",
+    "    else:\n",
+    "        df.plot.bar(y=airport, title=title, rot=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ui_callback(airport, years, df):\n",
+    "    plot_penalty_time_series(airport, range(years[0], years[1] + 1), df)\n",
+    "    plot_average_penalty(airport, range(years[0], years[1] + 1), df)\n",
+    "\n",
+    "# Years selection range\n",
+    "years = range(1994, 2009)\n",
+    "years = [(str(y), y) for y in years]\n",
+    "years_w = widgets.SelectionRangeSlider(options=years,\n",
+    "                                       index=(0, 2),\n",
+    "                                       description='Years',\n",
+    "                                       continuous_update=False)\n",
+    "# Airport selection menu\n",
+    "airports_w = widgets.Dropdown(options=airports,\n",
+    "                              value=airports[0],\n",
+    "                              description='Airport')\n",
+    "\n",
+    "ui = widgets.HBox([airports_w, years_w])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d9978d8e686a4301bd609c30fca44ee0",
+       "model_id": "da1c27942206409abbb1ceaebe74b2f7",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "interactive(children=(Dropdown(description='Airport', options=('ABE', 'ABI', 'ABQ', 'ABY', 'ACK', 'ACT', 'ACV'…"
+       "HBox(children=(Dropdown(description='Airport', options=('ABE', 'ABI', 'ABQ', 'ABY', 'ACK', 'ACT', 'ACV', 'ACY'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "aed524788d55411db00255d4749e5b4d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
       ]
      },
      "metadata": {},
@@ -335,18 +428,8 @@
     }
    ],
    "source": [
-    "years = range(1994, 2009)\n",
-    "options = [(str(y), y) for y in years]\n",
-    "years_w = widgets.SelectionRangeSlider(options=options,\n",
-    "                                       index=(0, 2),\n",
-    "                                       description='Years',\n",
-    "                                       continuous_update=False)\n",
-    "airports_w = widgets.Dropdown(options=airports,\n",
-    "                              value=airports[0],\n",
-    "                              description='Airport')\n",
-    "@interact(airport=airports_w, years=years_w, df=fixed(penalties))\n",
-    "def g(airport, years, df):\n",
-    "    plot_penalty_time_series(airport, range(years[0], years[1] + 1), penalties)"
+    "out = widgets.interactive_output(ui_callback, {'airport': airports_w, 'years': years_w, 'df': widgets.fixed(penalties)})\n",
+    "display(ui, out)"
    ]
   }
  ],


### PR DESCRIPTION
Apparently executing multiple `join` with Spark SQL is inefficient in case we operate on small tables. In fact, joining 10 rows into columns would take an unreasonable amount of seconds. 

Therefore the code has been changed to manually create Pandas `Dataframe` to plot, making data computation much faster.